### PR TITLE
Add GitHub workflow to run pre-commit on all files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,8 +49,20 @@ updates:
         patterns:
           - "pre-commit*"
 
-  # Maintain dependencies for Devcontainer dependencies
+  # Maintain dependencies for Devcontainer
   - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "chore"
+    groups:
+      devcontainer:
+        patterns:
+          - "*"
+
+  # Maintain dependencies for pre-commit
+  - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,38 @@
+---
+name: Pre-commit
+
+on: # yamllint disable-line rule:truthy - false positive
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  pre-commit:
+    name: Pre-commit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -29,10 +29,13 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
-          python-version: "3.12"
+          python-version: "3.14"
 
       - name: Install pre-commit
         run: pip install pre-commit
 
+      - name: Validate pre-commit config
+        run: pre-commit validate-config
+
       - name: Run pre-commit on all files
-        run: pre-commit run --all-files
+        run: pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
 
   # Sort all Python import statements
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.1
+    rev: 8.0.1
     hooks:
       - id: isort
         name: isort (Python)
@@ -15,7 +15,7 @@ repos:
 
   # Automatically fix outdated Python syntax
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.19.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         name: pyupgrade (Python)
@@ -23,7 +23,7 @@ repos:
 
   # Beautify Python
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
       - id: black
         name: black (Python)
@@ -32,7 +32,7 @@ repos:
   # Linters to validate beautifiers output
   ########################################
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-ast
       - id: check-case-conflict

--- a/tests/test_gimmie.py
+++ b/tests/test_gimmie.py
@@ -8,7 +8,6 @@ from urllib.parse import urlparse
 import pytest
 import requests
 import responses
-
 from gimmie.main import (
     apply_retry_backoff,
     cleanup_download,

--- a/tests/test_gimmie.py
+++ b/tests/test_gimmie.py
@@ -1,13 +1,3 @@
-import os
-import shutil
-import tempfile
-import time
-from io import BytesIO
-from urllib.parse import urlparse
-
-import pytest
-import requests
-import responses
 from gimmie.main import (
     apply_retry_backoff,
     cleanup_download,
@@ -21,6 +11,17 @@ from gimmie.main import (
     prepare_file_paths,
     read_urls_from_file,
 )
+
+from io import BytesIO
+
+import os
+import pytest
+import requests
+import responses
+import shutil
+import tempfile
+import time
+from urllib.parse import urlparse
 
 
 @pytest.fixture

--- a/tests/test_gimmie.py
+++ b/tests/test_gimmie.py
@@ -1,3 +1,14 @@
+import os
+import shutil
+import tempfile
+import time
+from io import BytesIO
+from urllib.parse import urlparse
+
+import pytest
+import requests
+import responses
+
 from gimmie.main import (
     apply_retry_backoff,
     cleanup_download,
@@ -11,17 +22,6 @@ from gimmie.main import (
     prepare_file_paths,
     read_urls_from_file,
 )
-
-from io import BytesIO
-
-import os
-import pytest
-import requests
-import responses
-import shutil
-import tempfile
-import time
-from urllib.parse import urlparse
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pre-commit.yml` that runs `pre-commit run --all-files` on every push and pull request to `main`/`master`
- Ensures all hooks defined in `.pre-commit-config.yaml` (isort, pyupgrade, black, and pre-commit-hooks) are enforced in CI, even if not run locally

Closes #68

## Test plan

- [x] Workflow appears under Actions on a push/PR
- [x] Workflow passes on a clean branch
- [x] Workflow fails if a hook violation is introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)